### PR TITLE
Catch SSL Errors and Warnings.

### DIFF
--- a/operator_client/v1/architect.py
+++ b/operator_client/v1/architect.py
@@ -23,6 +23,10 @@ class ArchitectClient(BaseClient):
 
         if response.status_code == 200:
             output = response.json()
+        elif response.status_code == 526:
+            output = "SSLError"
+        elif response.status_code == 525:
+            output = "SSLCertMissing"
         else:
             output = None
 


### PR DESCRIPTION
Catch SSL Errors and Warnings.

Now if someone passes an invalid SSL certificate, a fake response will be passed with a 526 response code.

Now if someone uses a URL with https:// and manages to ignore verification, catch the urllib3 warning and return a fake response with a 525 response code.

The health route will now check status code and respond accordingly. 